### PR TITLE
Feat/update message support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,3 +48,7 @@ set(HEADERS
 install(DIRECTORY include/ DESTINATION /usr/local/include/AppwriteSDK)
 install(FILES ${HEADERS} DESTINATION /usr/local/include/AppwriteSDK)
 install(TARGETS AppwriteSDK ARCHIVE DESTINATION /usr/local/lib)
+
+# ---- Build example: updateMessage ----
+add_executable(updateMessage examples/messaging/messages/updateMessage.cpp)
+target_link_libraries(updateMessage AppwriteSDK CURL::libcurl)

--- a/examples/messaging/messages/updateMessage.cpp
+++ b/examples/messaging/messages/updateMessage.cpp
@@ -1,0 +1,24 @@
+#include "classes/Messaging.hpp"
+#include <iostream>
+
+int main() {
+    std::string projectId = "<your-project-id>";
+    std::string apiKey = "<your-api-key>";
+    std::string messageId = "<existing-message-id>";
+
+    Messaging messaging(projectId, apiKey);
+
+    try {
+        std::string updated = messaging.updateMessage(
+            messageId,
+            "New subject from C++ SDK",
+            "Updated content body using updateMessage()"
+        );
+
+        std::cout << "Message updated: " << updated << std::endl;
+    } catch (const AppwriteException &ex) {
+        std::cerr << "Appwrite error: " << ex.what() << std::endl;
+    }
+
+    return 0;
+}

--- a/include/classes/Messaging.hpp
+++ b/include/classes/Messaging.hpp
@@ -1,3 +1,5 @@
+// Messaging.hpp
+
 #ifndef MESSAGING_HPP
 #define MESSAGING_HPP
 
@@ -31,6 +33,10 @@ class Messaging {
                                   const std::string &name,
                                   const std::string &targetId,
                                   const std::string &subscriberId);
+
+    std::string updateMessage(const std::string &messageId,
+                              const std::string &subject,
+                              const std::string &content);
 
   private:
     std::string projectId;

--- a/src/services/Messaging.cpp
+++ b/src/services/Messaging.cpp
@@ -340,3 +340,36 @@ std::string Messaging::createSubscribers(const std::string &topicId,
                                 "\n\nResponse: " + response);
     }
 }
+std::string Messaging::updateMessage(const std::string &messageId,
+                                     const std::string &subject,
+                                     const std::string &content) {
+    if (messageId.empty()) {
+        throw AppwriteException("Missing required parameter: 'messageId'");
+    }
+    if (subject.empty()) {
+        throw AppwriteException("Missing required parameter: 'subject'");
+    }
+    if (content.empty()) {
+        throw AppwriteException("Missing required parameter: 'content'");
+    }
+
+    std::string url = Config::API_BASE_URL + "/messaging/messages/" + Utils::urlEncode(messageId);
+
+    std::string payload = R"({"subject":")" + Utils::escapeJsonString(subject) +
+                          R"(","content":")" + Utils::escapeJsonString(content) + R"("})";
+
+    std::vector<std::string> headers = Config::getHeaders(projectId);
+    headers.push_back("X-Appwrite-Key: " + apiKey);
+    headers.push_back("Content-Type: application/json");
+
+    std::string response;
+    int statusCode = Utils::patchRequest(url, payload, headers, response);
+
+    if (statusCode == HttpStatus::OK) {
+        return response;
+    } else {
+        throw AppwriteException("Error updating message. Status code: " +
+                                std::to_string(statusCode) +
+                                "\n\nResponse: " + response);
+    }
+}


### PR DESCRIPTION
🚀 Feature: Add updateMessage Support to Messaging API
✨ Description
This PR introduces support for the updateMessage method in the Messaging service of the Appwrite C++ SDK. It allows developers to update the subject and content of an existing message using its messageId.

📦 Changes Made
Implemented Messaging::updateMessage() in Messaging.cpp

Declared the new method in Messaging.hpp

Added a usage example: examples/messaging/messages/updateMessage.cpp

Updated CMakeLists.txt to include the example

🧪 Test Instructions
Make sure the X-Appwrite-Project and X-Appwrite-Key are set correctly in your example.

Run the example with:

bash
Copy
Edit
./updateMessage
Confirm the response indicates successful update (200 OK) or appropriate error.

📝 Notes
Handles validation for required parameters: messageId, subject, and content

Follows the existing SDK architecture and error-handling strategy

