### PR TITLE
Feat/update email message

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,3 +48,7 @@ set(HEADERS
 install(DIRECTORY include/ DESTINATION /usr/local/include/AppwriteSDK)
 install(FILES ${HEADERS} DESTINATION /usr/local/include/AppwriteSDK)
 install(TARGETS AppwriteSDK ARCHIVE DESTINATION /usr/local/lib)
+
+# ---- Build example: updateMessage ----
+add_executable(updateMessage examples/messaging/messages/updateMessage.cpp)
+target_link_libraries(updateMessage AppwriteSDK CURL::libcurl)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,6 +49,3 @@ install(DIRECTORY include/ DESTINATION /usr/local/include/AppwriteSDK)
 install(FILES ${HEADERS} DESTINATION /usr/local/include/AppwriteSDK)
 install(TARGETS AppwriteSDK ARCHIVE DESTINATION /usr/local/lib)
 
-# ---- Build example: updateMessage ----
-add_executable(updateMessage examples/messaging/messages/updateMessage.cpp)
-target_link_libraries(updateMessage AppwriteSDK CURL::libcurl)

--- a/Makefile
+++ b/Makefile
@@ -276,3 +276,10 @@ deleteSubscribers: $(SRCS) $(EXAMPLES_DIR)/messaging/subscribers/deleteSubscribe
 createSubscribers: $(SRCS) $(EXAMPLES_DIR)/messaging/subscribers/createSubscribers.cpp
 			@mkdir -p ./$(TESTS_DIR)
 			$(CXX) $(CXXFLAGS) -o ./$(TESTS_DIR)/createSubscribers $(SRCS) $(EXAMPLES_DIR)/messaging/subscribers/createSubscribers.cpp $(LDFLAGS)
+# Messaging - messages			
+createEmailMessage: $(SRCS) $(EXAMPLES_DIR)/messaging/messages/createEmailMessage.cpp
+	@mkdir -p ./$(TESTS_DIR)
+	$(CXX) $(CXXFLAGS) -o ./$(TESTS_DIR)/createEmailMessage $(SRCS) $(EXAMPLES_DIR)/messaging/messages/createEmailMessage.cpp $(LDFLAGS)
+updateMessage: $(SRCS) $(EXAMPLES_DIR)/messaging/messages/updateMessage.cpp
+	@mkdir -p ./$(TESTS_DIR)
+	$(CXX) $(CXXFLAGS) -o ./$(TESTS_DIR)/updateMessage $(SRCS) $(EXAMPLES_DIR)/messaging/messages/updateMessage.cpp $(LDFLAGS)

--- a/Makefile
+++ b/Makefile
@@ -276,10 +276,8 @@ deleteSubscribers: $(SRCS) $(EXAMPLES_DIR)/messaging/subscribers/deleteSubscribe
 createSubscribers: $(SRCS) $(EXAMPLES_DIR)/messaging/subscribers/createSubscribers.cpp
 			@mkdir -p ./$(TESTS_DIR)
 			$(CXX) $(CXXFLAGS) -o ./$(TESTS_DIR)/createSubscribers $(SRCS) $(EXAMPLES_DIR)/messaging/subscribers/createSubscribers.cpp $(LDFLAGS)
-# Messaging - messages			
-createMessage: $(SRCS) $(EXAMPLES_DIR)/messaging/messages/createMessage.cpp
-	@mkdir -p ./$(TESTS_DIR)
-	$(CXX) $(CXXFLAGS) -o ./$(TESTS_DIR)/createMessage $(SRCS) $(EXAMPLES_DIR)/messaging/messages/createMessage.cpp $(LDFLAGS)
+			
+# Messaging - messages
 updateMessage: $(SRCS) $(EXAMPLES_DIR)/messaging/messages/updateMessage.cpp
 	@mkdir -p ./$(TESTS_DIR)
 	$(CXX) $(CXXFLAGS) -o ./$(TESTS_DIR)/updateMessage $(SRCS) $(EXAMPLES_DIR)/messaging/messages/updateMessage.cpp $(LDFLAGS)

--- a/Makefile
+++ b/Makefile
@@ -277,9 +277,9 @@ createSubscribers: $(SRCS) $(EXAMPLES_DIR)/messaging/subscribers/createSubscribe
 			@mkdir -p ./$(TESTS_DIR)
 			$(CXX) $(CXXFLAGS) -o ./$(TESTS_DIR)/createSubscribers $(SRCS) $(EXAMPLES_DIR)/messaging/subscribers/createSubscribers.cpp $(LDFLAGS)
 # Messaging - messages			
-createEmailMessage: $(SRCS) $(EXAMPLES_DIR)/messaging/messages/createEmailMessage.cpp
+createMessage: $(SRCS) $(EXAMPLES_DIR)/messaging/messages/createMessage.cpp
 	@mkdir -p ./$(TESTS_DIR)
-	$(CXX) $(CXXFLAGS) -o ./$(TESTS_DIR)/createEmailMessage $(SRCS) $(EXAMPLES_DIR)/messaging/messages/createEmailMessage.cpp $(LDFLAGS)
+	$(CXX) $(CXXFLAGS) -o ./$(TESTS_DIR)/createMessage $(SRCS) $(EXAMPLES_DIR)/messaging/messages/createMessage.cpp $(LDFLAGS)
 updateMessage: $(SRCS) $(EXAMPLES_DIR)/messaging/messages/updateMessage.cpp
 	@mkdir -p ./$(TESTS_DIR)
 	$(CXX) $(CXXFLAGS) -o ./$(TESTS_DIR)/updateMessage $(SRCS) $(EXAMPLES_DIR)/messaging/messages/updateMessage.cpp $(LDFLAGS)

--- a/examples/messaging/messages/createEmailMessage.cpp
+++ b/examples/messaging/messages/createEmailMessage.cpp
@@ -1,0 +1,22 @@
+#include "classes/Messaging.hpp"
+#include <iostream>
+
+int main() {
+    try {
+        Messaging messaging("your-project-id", "your-api-key");
+
+        std::string response = messaging.createEmailMessage(
+            "Welcome to the platform!",
+            "Thank you for signing up. Stay tuned for updates.",
+            "welcome-topic-id",
+            "admin@example.com",
+            "Admin Team"
+        );
+
+        std::cout << "Email created: " << response << std::endl;
+    } catch (const AppwriteException &e) {
+        std::cerr << "Appwrite error: " << e.what() << std::endl;
+    }
+
+    return 0;
+}

--- a/examples/messaging/messages/createEmailMessage.cpp
+++ b/examples/messaging/messages/createEmailMessage.cpp
@@ -1,22 +1,29 @@
-#include "classes/Messaging.hpp"
+#include "Appwrite.hpp"
 #include <iostream>
 
 int main() {
+    std::string projectId = "<your_project_id>";
+    std::string apiKey = "<your_api_key>";  
+    Appwrite appwrite(projectId, apiKey);
+
+    std::string messageId = "<your_message_id>";
+    std::string subject = "Hello from C++ Appwrite SDK!";
+    std::string content = "Testing email message creation with topics and targets.";
+
+    std::vector<std::string> topics = {"<topic_id>"};
+    std::vector<std::string> targets = {"<target_id>"};
+
     try {
-        Messaging messaging("your-project-id", "your-api-key");
-
-        std::string response = messaging.createEmailMessage(
-            "Welcome to the platform!",
-            "Thank you for signing up. Stay tuned for updates.",
-            "welcome-topic-id",
-            "admin@example.com",
-            "Admin Team"
+        std::string response = appwrite.getMessaging().createEmailMessage(
+            messageId, subject, content, topics, targets
         );
-
-        std::cout << "Email created: " << response << std::endl;
-    } catch (const AppwriteException &e) {
-        std::cerr << "Appwrite error: " << e.what() << std::endl;
+        std::cout << "Email Message Created!\nResponse: " << response << std::endl;
+    } catch (const AppwriteException& ex) {
+        std::cerr << "Exception: " << ex.what() << std::endl;
     }
 
     return 0;
 }
+
+
+

--- a/examples/messaging/messages/createMessage.cpp
+++ b/examples/messaging/messages/createMessage.cpp
@@ -2,19 +2,20 @@
 #include <iostream>
 
 int main() {
-    std::string projectId = "<your_project_id>";
-    std::string apiKey = "<your_api_key>";  
-    Appwrite appwrite(projectId, apiKey);
+    std::string projectId = "<your_project_id>";  
+    std::string apiKey = "<your_api_key>";
+
+    Appwrite appwrite(projectId, apiKey);   
 
     std::string messageId = "<your_message_id>";
     std::string subject = "Hello from C++ Appwrite SDK!";
     std::string content = "Testing email message creation with topics and targets.";
 
-    std::vector<std::string> topics = {"<topic_id>"};
-    std::vector<std::string> targets = {"<target_id>"};
+    std::vector<std::string> topics = {"<topic_id>"};     
+    std::vector<std::string> targets = {"<target_id>"};   
 
     try {
-        std::string response = appwrite.getMessaging().createEmailMessage(
+        std::string response = appwrite.getMessaging().createMessage(
             messageId, subject, content, topics, targets
         );
         std::cout << "Email Message Created!\nResponse: " << response << std::endl;
@@ -24,6 +25,5 @@ int main() {
 
     return 0;
 }
-
 
 

--- a/examples/messaging/messages/updateMessage.cpp
+++ b/examples/messaging/messages/updateMessage.cpp
@@ -1,23 +1,23 @@
-#include "classes/Messaging.hpp"
+#include "Appwrite.hpp"
 #include <iostream>
 
 int main() {
-    std::string projectId = "<your-project-id>";
-    std::string apiKey = "<your-api-key>";
-    std::string messageId = "<existing-message-id>";
+    std::string projectId = "<project-id>";
+    std::string apiKey = "<api-key>";
 
-    Messaging messaging(projectId, apiKey);
+    Appwrite appwrite(projectId, apiKey);
+
+    std::string messageId = "<existing-email-message-id>";
+    std::string subject = "Updated Subject from C++";
+    std::string content = "Updated content of the email from C++ SDK.";
 
     try {
-        std::string updated = messaging.updateMessage(
-            messageId,
-            "New subject from C++ SDK",
-            "Updated content body using updateMessage()"
+        std::string response = appwrite.getMessaging().updateMessage(
+            messageId, subject, content
         );
-
-        std::cout << "Message updated: " << updated << std::endl;
+        std::cout << "Email Message Updated!\nResponse: " << response << std::endl;
     } catch (const AppwriteException &ex) {
-        std::cerr << "Appwrite error: " << ex.what() << std::endl;
+        std::cerr << "Exception: " << ex.what() << std::endl;
     }
 
     return 0;

--- a/examples/messaging/messages/updateMessage.cpp
+++ b/examples/messaging/messages/updateMessage.cpp
@@ -1,0 +1,24 @@
+#include "classes/Messaging.hpp"
+#include <iostream>
+
+int main() {
+    std::string projectId = "<your-project-id>";
+    std::string apiKey = "<your-api-key>";
+    std::string messageId = "<existing-message-id>";
+
+    Messaging messaging(projectId, apiKey);
+
+    try {
+        std::string updated = messaging.updateMessage(
+            messageId,
+            "New subject from C++ SDK",
+            "Updated content body using updateMessage()"
+        );
+
+        std::cout << "Message updated: " << updated << std::endl;
+    } catch (const AppwriteException &ex) {
+        std::cerr << "Appwrite error: " << ex.what() << std::endl;
+    }
+
+    return 0;
+}

--- a/include/classes/Messaging.hpp
+++ b/include/classes/Messaging.hpp
@@ -33,6 +33,16 @@ class Messaging {
                                   const std::string &name,
                                   const std::string &targetId,
                                   const std::string &subscriberId);
+    std::string createEmailMessage(const std::string& messageId,
+                               const std::string& subject,
+                               const std::string& content,
+                               const std::vector<std::string>& topics = {},
+                               const std::vector<std::string>& targets = {});
+
+
+    std::string updateMessage(const std::string &messageId,
+                          const std::string &subject,
+                          const std::string &content);
 
     std::string updateMessage(const std::string &messageId,
                               const std::string &subject,

--- a/include/classes/Messaging.hpp
+++ b/include/classes/Messaging.hpp
@@ -37,6 +37,13 @@ class Messaging {
     std::string updateMessage(const std::string &messageId,
                               const std::string &subject,
                               const std::string &content);
+                              
+    std::string createEmailMessage(const std::string &subject,
+                               const std::string &content,
+                               const std::string &topicId,
+                               const std::string &senderEmail,
+                               const std::string &senderName);
+
 
   private:
     std::string projectId;

--- a/include/classes/Messaging.hpp
+++ b/include/classes/Messaging.hpp
@@ -33,12 +33,6 @@ class Messaging {
                                   const std::string &name,
                                   const std::string &targetId,
                                   const std::string &subscriberId);
-     std::string createMessage(const std::string& messageId,
-                               const std::string& subject,
-                               const std::string& content,
-                               const std::vector<std::string>& topics = {},
-                               const std::vector<std::string>& targets = {});
-
     std::string updateMessage(const std::string &messageId,
                           const std::string &subject,
                           const std::string &content);

--- a/include/classes/Messaging.hpp
+++ b/include/classes/Messaging.hpp
@@ -1,3 +1,5 @@
+// Messaging.hpp
+
 #ifndef MESSAGING_HPP
 #define MESSAGING_HPP
 
@@ -31,6 +33,10 @@ class Messaging {
                                   const std::string &name,
                                   const std::string &targetId,
                                   const std::string &subscriberId);
+
+    std::string updateMessage(const std::string &messageId,
+                              const std::string &subject,
+                              const std::string &content);
 
   private:
     std::string projectId;

--- a/include/classes/Messaging.hpp
+++ b/include/classes/Messaging.hpp
@@ -33,28 +33,16 @@ class Messaging {
                                   const std::string &name,
                                   const std::string &targetId,
                                   const std::string &subscriberId);
-    std::string createEmailMessage(const std::string& messageId,
+     std::string createMessage(const std::string& messageId,
                                const std::string& subject,
                                const std::string& content,
                                const std::vector<std::string>& topics = {},
                                const std::vector<std::string>& targets = {});
 
-
     std::string updateMessage(const std::string &messageId,
                           const std::string &subject,
                           const std::string &content);
-
-    std::string updateMessage(const std::string &messageId,
-                              const std::string &subject,
-                              const std::string &content);
                               
-    std::string createEmailMessage(const std::string &subject,
-                               const std::string &content,
-                               const std::string &topicId,
-                               const std::string &senderEmail,
-                               const std::string &senderName);
-
-
   private:
     std::string projectId;
     std::string apiKey;

--- a/src/services/Messaging.cpp
+++ b/src/services/Messaging.cpp
@@ -373,3 +373,37 @@ std::string Messaging::updateMessage(const std::string &messageId,
                                 "\n\nResponse: " + response);
     }
 }
+
+std::string Messaging::createEmailMessage(const std::string &subject,
+                                          const std::string &content,
+                                          const std::string &topicId,
+                                          const std::string &senderEmail,
+                                          const std::string &senderName) {
+    if (subject.empty() || content.empty() || topicId.empty() || senderEmail.empty() || senderName.empty()) {
+        throw AppwriteException("Missing required parameters to create email message.");
+    }
+
+    std::string url = Config::API_BASE_URL + "/messaging/messages/email";
+
+    std::string payload =
+        R"({"subject":")" + Utils::escapeJsonString(subject) +
+        R"(","content":")" + Utils::escapeJsonString(content) +
+        R"(","topicId":")" + Utils::escapeJsonString(topicId) +
+        R"(","sender": { "email":")" + Utils::escapeJsonString(senderEmail) +
+        R"(","name":")" + Utils::escapeJsonString(senderName) + R"("}})";
+
+    std::vector<std::string> headers = Config::getHeaders(projectId);
+    headers.push_back("X-Appwrite-Key: " + apiKey);
+    headers.push_back("Content-Type: application/json");
+
+    std::string response;
+    int statusCode = Utils::postRequest(url, payload, headers, response);
+
+    if (statusCode == HttpStatus::CREATED) {
+        return response;
+    } else {
+        throw AppwriteException("Error creating email message. Status code: " +
+                                std::to_string(statusCode) + "\n\nResponse: " + response);
+    }
+}
+

--- a/src/services/Messaging.cpp
+++ b/src/services/Messaging.cpp
@@ -340,7 +340,7 @@ std::string Messaging::createSubscribers(const std::string &topicId,
                                 "\n\nResponse: " + response);
     }
 }
-std::string Messaging::createEmailMessage(const std::string& messageId,
+std::string Messaging::createMessage(const std::string& messageId,
                                           const std::string& subject,
                                           const std::string& content,
                                           const std::vector<std::string>& topics,
@@ -398,12 +398,11 @@ std::string Messaging::createEmailMessage(const std::string& messageId,
                                 std::to_string(statusCode) + "\n\nResponse: " + response);
     }
 }
-
-
-
-std::string Messaging::updateMessage(const std::string &messageId,
-                                     const std::string &subject,
-                                     const std::string &content) {
+std::string Messaging::updateMessage(
+    const std::string& messageId,
+    const std::string& subject,
+    const std::string& content
+) {
     if (messageId.empty()) {
         throw AppwriteException("Missing required parameter: 'messageId'");
     }
@@ -413,8 +412,7 @@ std::string Messaging::updateMessage(const std::string &messageId,
     if (content.empty()) {
         throw AppwriteException("Missing required parameter: 'content'");
     }
-
-    std::string url = Config::API_BASE_URL + "/messaging/messages/" + Utils::urlEncode(messageId);
+    std::string url = Config::API_BASE_URL + "/messaging/messages/email/" + Utils::urlEncode(messageId);
 
     std::string payload = R"({"subject":")" + Utils::escapeJsonString(subject) +
                           R"(","content":")" + Utils::escapeJsonString(content) + R"("})";
@@ -426,10 +424,10 @@ std::string Messaging::updateMessage(const std::string &messageId,
     std::string response;
     int statusCode = Utils::patchRequest(url, payload, headers, response);
 
-    if (statusCode == HttpStatus::OK) {
+    if (statusCode == HttpStatus::OK || statusCode == HttpStatus::CREATED) {
         return response;
     } else {
-        throw AppwriteException("Error updating message. Status code: " +
-                                std::to_string(statusCode) + "\n\nResponse: " + response);
+        throw AppwriteException("Error updating message. Status code: " + std::to_string(statusCode) +
+                                "\n\nResponse: " + response);
     }
 }

--- a/src/services/Messaging.cpp
+++ b/src/services/Messaging.cpp
@@ -340,64 +340,7 @@ std::string Messaging::createSubscribers(const std::string &topicId,
                                 "\n\nResponse: " + response);
     }
 }
-std::string Messaging::createMessage(const std::string& messageId,
-                                          const std::string& subject,
-                                          const std::string& content,
-                                          const std::vector<std::string>& topics,
-                                          const std::vector<std::string>& targets) {
-    if (messageId.empty()) {
-        throw AppwriteException("Missing required parameter: 'messageId'");
-    }
-    if (subject.empty()) {
-        throw AppwriteException("Missing required parameter: 'subject'");
-    }
-    if (content.empty()) {
-        throw AppwriteException("Missing required parameter: 'content'");
-    }
-    if (topics.empty() && targets.empty()) {
-        throw AppwriteException("At least one of 'topics' or 'targets' must be provided");
-    }
 
-    std::string payload = R"({"messageId":")" + Utils::escapeJsonString(messageId) +
-                          R"(","subject":")" + Utils::escapeJsonString(subject) +
-                          R"(","content":")" + Utils::escapeJsonString(content) + R"(")";
-
-    if (!topics.empty()) {
-        payload += R"(,"topics":[)";
-        for (size_t i = 0; i < topics.size(); ++i) {
-            payload += "\"" + Utils::escapeJsonString(topics[i]) + "\"";
-            if (i != topics.size() - 1) payload += ",";
-        }
-        payload += "]";
-    }
-
-    if (!targets.empty()) {
-        payload += R"(,"targets":[)";
-        for (size_t i = 0; i < targets.size(); ++i) {
-            payload += "\"" + Utils::escapeJsonString(targets[i]) + "\"";
-            if (i != targets.size() - 1) payload += ",";
-        }
-        payload += "]";
-    }
-
-    payload += "}";
-
-    std::string url = Config::API_BASE_URL + "/messaging/messages/email";
-
-    std::vector<std::string> headers = Config::getHeaders(projectId);
-    headers.push_back("X-Appwrite-Key: " + apiKey);
-    headers.push_back("Content-Type: application/json");
-
-    std::string response;
-    int statusCode = Utils::postRequest(url, payload, headers, response);
-
-    if (statusCode == HttpStatus::CREATED || statusCode == HttpStatus::OK) {
-        return response;
-    } else {
-        throw AppwriteException("Error creating email message. Status code: " +
-                                std::to_string(statusCode) + "\n\nResponse: " + response);
-    }
-}
 std::string Messaging::updateMessage(
     const std::string& messageId,
     const std::string& subject,

--- a/src/services/Messaging.cpp
+++ b/src/services/Messaging.cpp
@@ -340,3 +340,36 @@ std::string Messaging::createSubscribers(const std::string &topicId,
                                 "\n\nResponse: " + response);
     }
 }
+std::string Messaging::updateMessage(const std::string &messageId,
+                                     const std::string &subject,
+                                     const std::string &content) {
+    if (messageId.empty()) {
+        throw AppwriteException("Missing required parameter: 'messageId'");
+    }
+    if (subject.empty()) {
+        throw AppwriteException("Missing required parameter: 'subject'");
+    }
+    if (content.empty()) {
+        throw AppwriteException("Missing required parameter: 'content'");
+    }
+
+    std::string url = Config::API_BASE_URL + "/messaging/messages/" + Utils::urlEncode(messageId);
+
+    std::string payload = R"({"subject":")" + Utils::escapeJsonString(subject) +
+                          R"(","content":")" + Utils::escapeJsonString(content) + R"("})";
+
+    std::vector<std::string> headers = Config::getHeaders(projectId);
+    headers.push_back("X-Appwrite-Key: " + apiKey);
+    headers.push_back("Content-Type: application/json");
+
+    std::string response;
+    int statusCode = Utils::patchRequest(url, payload, headers, response);
+
+    if (statusCode == HttpStatus::OK) {
+        return response;
+    } else {
+        throw AppwriteException("Error updating message. Status code: " +
+                                std::to_string(statusCode) +
+                                "\n\nResponse: " + response);
+    }
+}


### PR DESCRIPTION
# 🚀 Feature: Add `updateEmailMessage` API to Messaging Module

## 📌 Summary

This PR adds support for updating an existing email message in the Appwrite Messaging module using the C++ SDK. It follows the structure of other SDKs and is aligned with the official Appwrite API.

---

## ✅ Changes Made

- ### 🔓 Public Method Declaration in `Messaging.hpp`:
  ```cpp
  std::string updateMessage(
      const std::string& messageId,
      const std::string& subject,
      const std::string& content
  );
🧠 Implementation in Messaging.cpp:
Validates parameters

Constructs JSON payload

Sends a PATCH request to:

swift
Copy
Edit
/messaging/messages/email/{messageId}
Handles:

Successful update response

Error cases (e.g., already failed message)

🧪 Example Added:
File: examples/messaging/messages/updateMessage.cpp

cpp
Copy
Edit
std::string response = appwrite.getMessaging().updateMessage(
    "unique-message-id-0101",
    "Updated Subject",
    "Updated content for the email message."
);
🛠️ Makefile Updated:
Added:

bash
Copy
Edit
make updateMessage
./tests/updateMessage
📚 References
Appwrite Docs – Update Email Message

✅ Checklist
 Follows Appwrite API structure

 Validates required parameters

 Tested with valid and invalid message IDs

 Example included

 Makefile target added