### PR TITLE
feat: createEmail

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -249,6 +249,9 @@ listMessages: $(SRCS) $(EXAMPLES_DIR)/messaging/messages/listMessages.cpp
 getMessages: $(SRCS) $(EXAMPLES_DIR)/messaging/messages/getMessages.cpp
 			@mkdir -p ./$(TESTS_DIR)
 			$(CXX) $(CXXFLAGS) -o ./$(TESTS_DIR)/getMessages $(SRCS) $(EXAMPLES_DIR)/messaging/messages/getMessages.cpp $(LDFLAGS)
+createMessage: $(SRCS) $(EXAMPLES_DIR)/messaging/messages/createMessage.cpp
+	@mkdir -p ./$(TESTS_DIR)
+	$(CXX) $(CXXFLAGS) -o ./$(TESTS_DIR)/createMessage $(SRCS) $(EXAMPLES_DIR)/messaging/messages/createMessage.cpp $(LDFLAGS)
 
 # Messaging - Topics
 getTopic: $(SRCS) $(EXAMPLES_DIR)/messaging/topics/getTopic.cpp

--- a/examples/messaging/messages/createMessage.cpp
+++ b/examples/messaging/messages/createMessage.cpp
@@ -1,0 +1,27 @@
+#include "Appwrite.hpp"
+#include <iostream>
+
+int main() {
+    std::string projectId = "<your_project_id>";  
+    std::string apiKey = "<your_api_key>";
+
+    Appwrite appwrite(projectId, apiKey);   
+
+    std::string messageId = "<your_message_id>";
+    std::string subject = "Hello from C++ Appwrite SDK!";
+    std::string content = "Testing email message creation with topics and targets.";
+
+    std::vector<std::string> topics = {"<topic_id>"};     
+    std::vector<std::string> targets = {"<target_id>"};   
+
+    try {
+        std::string response = appwrite.getMessaging().createMessage(
+            messageId, subject, content, topics, targets
+        );
+        std::cout << "Email Message Created!\nResponse: " << response << std::endl;
+    } catch (const AppwriteException& ex) {
+        std::cerr << "Exception: " << ex.what() << std::endl;
+    }
+
+    return 0;
+}

--- a/include/classes/Messaging.hpp
+++ b/include/classes/Messaging.hpp
@@ -119,7 +119,12 @@ class Messaging {
     std::string createPush(const std::string &messageId,
                                   const std::string &title,
                                   const std::string &body,
-                                  const std::string &topicId);                              
+                                  const std::string &topicId);     
+    std::string createMessage(const std::string& messageId,
+                               const std::string& subject,
+                               const std::string& content,
+                               const std::vector<std::string>& topics = {},
+                               const std::vector<std::string>& targets = {});                         
 
   private:
     std::string projectId; ///< Project ID

--- a/include/classes/Messaging.hpp
+++ b/include/classes/Messaging.hpp
@@ -120,6 +120,19 @@ class Messaging {
                                   const std::string &title,
                                   const std::string &body,
                                   const std::string &topicId);     
+    /**
+     * @brief Create a new email message.
+     * 
+     * Sends a new email message to specific topics and/or target recipients.
+     * At least one of `topics` or `targets` must be provided.
+     *
+     * @param messageId Unique ID for the message.
+     * @param subject Subject line of the email.
+     * @param content Body content of the email.
+     * @param topics List of topic IDs to send the message to (optional).
+     * @param targets List of target recipients (e.g., email:userId) (optional).
+     * @return JSON response.
+     */
     std::string createMessage(const std::string& messageId,
                                const std::string& subject,
                                const std::string& content,

--- a/src/services/Messaging.cpp
+++ b/src/services/Messaging.cpp
@@ -385,3 +385,61 @@ std::string Messaging::createPush(const std::string &messageId,
     } 
 }
 
+std::string Messaging::createMessage(const std::string& messageId,
+                                          const std::string& subject,
+                                          const std::string& content,
+                                          const std::vector<std::string>& topics,
+                                          const std::vector<std::string>& targets) {
+    if (messageId.empty()) {
+        throw AppwriteException("Missing required parameter: 'messageId'");
+    }
+    if (subject.empty()) {
+        throw AppwriteException("Missing required parameter: 'subject'");
+    }
+    if (content.empty()) {
+        throw AppwriteException("Missing required parameter: 'content'");
+    }
+    if (topics.empty() && targets.empty()) {
+        throw AppwriteException("At least one of 'topics' or 'targets' must be provided");
+    }
+
+    std::string payload = R"({"messageId":")" + Utils::escapeJsonString(messageId) +
+                          R"(","subject":")" + Utils::escapeJsonString(subject) +
+                          R"(","content":")" + Utils::escapeJsonString(content) + R"(")";
+
+    if (!topics.empty()) {
+        payload += R"(,"topics":[)";
+        for (size_t i = 0; i < topics.size(); ++i) {
+            payload += "\"" + Utils::escapeJsonString(topics[i]) + "\"";
+            if (i != topics.size() - 1) payload += ",";
+        }
+        payload += "]";
+    }
+
+    if (!targets.empty()) {
+        payload += R"(,"targets":[)";
+        for (size_t i = 0; i < targets.size(); ++i) {
+            payload += "\"" + Utils::escapeJsonString(targets[i]) + "\"";
+            if (i != targets.size() - 1) payload += ",";
+        }
+        payload += "]";
+    }
+
+    payload += "}";
+
+    std::string url = Config::API_BASE_URL + "/messaging/messages/email";
+
+    std::vector<std::string> headers = Config::getHeaders(projectId);
+    headers.push_back("X-Appwrite-Key: " + apiKey);
+    headers.push_back("Content-Type: application/json");
+
+    std::string response;
+    int statusCode = Utils::postRequest(url, payload, headers, response);
+
+    if (statusCode == HttpStatus::CREATED || statusCode == HttpStatus::OK) {
+        return response;
+    } else {
+        throw AppwriteException("Error creating email message. Status code: " +
+                                std::to_string(statusCode) + "\n\nResponse: " + response);
+    }
+}


### PR DESCRIPTION
✨ Feature: Add createMessage API to Messaging SDK
📌 Description
This PR adds the createMessage API implementation under the Messaging module of the Appwrite C++ SDK. The API allows users to create email messages using both topics and targets, similar to the official Appwrite Messaging reference.

🛠️ Changes Made
Declared method createMessage in Messaging.hpp

Implemented method in Messaging.cpp

Created usage example in examples/messaging/messages/createMessage.cpp

Added corresponding Makefile entry for building and testing the example

✅ Testing
Successfully tested with:

bash
Copy
Edit
make createMessage
./tests/createMessage

🔗 Reference
Appwrite Messaging API Reference: Appwrite Docs

Related Python SDK implementation: [Python SDK example](https://github.com/appwrite/sdk-for-python/blob/main/appwrite/services/messaging.py)

🧠 Notes
Ensure targets exist and are valid (via Appwrite Console)