### PR TITLE
feat: add createSms API to Messaging service with example

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,3 +48,6 @@ set(HEADERS
 install(DIRECTORY include/ DESTINATION /usr/local/include/AppwriteSDK)
 install(FILES ${HEADERS} DESTINATION /usr/local/include/AppwriteSDK)
 install(TARGETS AppwriteSDK ARCHIVE DESTINATION /usr/local/lib)
+
+add_executable(example-messaging-create-sms examples/messaging/messages/createSms.cpp)
+target_link_libraries(example-messaging-create-sms AppwriteSDK)

--- a/examples/messaging/messages/createSms.cpp
+++ b/examples/messaging/messages/createSms.cpp
@@ -1,0 +1,23 @@
+#include "Appwrite.hpp"
+#include <iostream>
+
+int main() {
+    std::string projectId = "<your_project_id>";
+    std::string apiKey = "<your_api_key>";
+
+    Appwrite appwrite(projectId, apiKey);
+
+    std::string recipient = "<recipient_number>";   // e.g., +911234567890
+    std::string message   = "Hello from C++ Appwrite SDK! (SMS Test)";
+
+    try {
+        std::string response = appwrite.getMessaging().createSms(
+            recipient, message
+        );
+        std::cout << "SMS Message Created!\nResponse: " << response << std::endl;
+    } catch (const AppwriteException& ex) {
+        std::cerr << "Exception: " << ex.what() << std::endl;
+    }
+
+    return 0;
+}

--- a/include/classes/Messaging.hpp
+++ b/include/classes/Messaging.hpp
@@ -9,6 +9,7 @@
 #include "enums/HttpStatus.hpp"
 #include "exceptions/AppwriteException.hpp"
 #include <string>
+#include <vector>
 
 /**
  * @class Messaging
@@ -138,7 +139,17 @@ class Messaging {
                                const std::string& content,
                                const std::vector<std::string>& topics = {},
                                const std::vector<std::string>& targets = {});                         
-
+    /**
+     * @brief Create a new SMS message.
+     *
+     * Sends an SMS message to a specific recipient phone number.
+     *
+     * @param recipient Phone number of the recipient (e.g., +911234567890).
+     * @param message   Text message content.
+     * @return JSON response.
+     */
+    std::string createSms(const std::string &recipient,
+                          const std::string &message);
   private:
     std::string projectId; ///< Project ID
     std::string apiKey;    ///< API Key

--- a/src/services/Messaging.cpp
+++ b/src/services/Messaging.cpp
@@ -443,3 +443,34 @@ std::string Messaging::createMessage(const std::string& messageId,
                                 std::to_string(statusCode) + "\n\nResponse: " + response);
     }
 }
+
+std::string Messaging::createSms(const std::string &recipient,
+                                 const std::string &message) {
+    if (recipient.empty()) {
+        throw AppwriteException("Missing required parameter: 'recipient'");
+    }
+    if (message.empty()) {
+        throw AppwriteException("Missing required parameter: 'message'");
+    }
+
+    std::string url = Config::API_BASE_URL + "/messaging/messages/sms";
+
+    std::string payload =
+        R"({"recipient":")" + Utils::escapeJsonString(recipient) +
+        R"(","content":")" + Utils::escapeJsonString(message) + R"("})";
+
+    std::vector<std::string> headers = Config::getHeaders(projectId);
+    headers.push_back("X-Appwrite-Key: " + apiKey);
+    headers.push_back("Content-Type: application/json");
+
+    std::string response;
+    int statusCode = Utils::postRequest(url, payload, headers, response);
+
+    if (statusCode == HttpStatus::CREATED || statusCode == HttpStatus::OK) {
+        return response;
+    } else {
+        throw AppwriteException("Error creating SMS message. Status code: " +
+                                std::to_string(statusCode) +
+                                "\n\nResponse: " + response);
+    }
+}


### PR DESCRIPTION
Added support for sending SMS messages via Appwrite Messaging API.

Implemented new function createSms() in Messaging service.

Added usage example (examples/messaging/messages/createSms.cpp).

Updated CMakeLists.txt to build the example.