### PR TITLE
feat: Added API for listTargets [messaging]

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -258,6 +258,9 @@ deleteMessages: $(SRCS) $(EXAMPLES_DIR)/messaging/messages/deleteMessages.cpp
 			@mkdir -p ./$(TESTS_DIR)
 			$(CXX) $(CXXFLAGS) -o ./$(TESTS_DIR)/deleteMessages $(SRCS) $(EXAMPLES_DIR)/messaging/messages/deleteMessages.cpp $(LDFLAGS)
 					
+listTargets: $(SRCS) $(EXAMPLES_DIR)/messaging/messages/listTargets.cpp
+	@mkdir -p ./$(TESTS_DIR)
+	$(CXX) $(CXXFLAGS) -o ./$(TESTS_DIR)/listTargets $(SRCS) $(EXAMPLES_DIR)/messaging/messages/listTargets.cpp $(LDFLAGS)
 # Messaging - Topics
 getTopic: $(SRCS) $(EXAMPLES_DIR)/messaging/topics/getTopic.cpp
 			@mkdir -p ./$(TESTS_DIR)

--- a/examples/messaging/messages/listTargets.cpp
+++ b/examples/messaging/messages/listTargets.cpp
@@ -1,0 +1,22 @@
+#include "Appwrite.hpp"
+#include "classes/Messaging.hpp"
+#include <iostream>
+
+int main() {
+    std::string projectId = "";
+    std::string apiKey = "";
+    std::string messageId = "";
+
+    std::vector<std::string> queries = {};
+
+    Appwrite appwrite(projectId, apiKey);
+
+    try {
+        std::string response = appwrite.getMessaging().listTargets(messageId, queries);
+        std::cout << "Message targets retrieved successfully:\n" << response << std::endl;
+    } catch (const AppwriteException &e) {
+        std::cerr << "Appwrite error: " << e.what() << std::endl;
+    }
+
+    return 0;
+}

--- a/include/classes/Messaging.hpp
+++ b/include/classes/Messaging.hpp
@@ -180,6 +180,15 @@ class Messaging {
      * @return JSON response.
      */
     std::string deleteMessages(const std::string &messageId);
+
+    /**
+     * @brief List all targets for a given message.
+     * @param messageId ID of the message.
+     * @param queries Optional query filters.
+     * @return JSON response.
+   */
+    std::string listTargets(const std::string &messageId, 
+                            const std::vector<std::string> &queries = {});
   private:
     std::string projectId; ///< Project ID
     std::string apiKey;    ///< API Key

--- a/src/services/Messaging.cpp
+++ b/src/services/Messaging.cpp
@@ -547,3 +547,35 @@ std::string Messaging::deleteMessages(const std::string &messageId) {
                                 "\nResponse: " + response);
     }
 }
+
+std::string Messaging::listTargets(const std::string &messageId, 
+                                   const std::vector<std::string> &queries) {
+    if (messageId.empty()) {
+        throw AppwriteException("Missing required parameter: 'messageId'");
+    }
+    
+    std::string url = Config::API_BASE_URL + "/messaging/messages/" + messageId + "/targets";
+    std::string queryParam = "";
+    if (!queries.empty()) {
+        queryParam += "?queries[]=" + Utils::urlEncode(queries[0]);
+        for (size_t i = 1; i < queries.size(); ++i) {
+            queryParam += "&queries[]=" + Utils::urlEncode(queries[i]);
+        }
+    }
+    
+    url += queryParam;
+    
+    std::vector<std::string> headers = Config::getHeaders(projectId);
+    headers.push_back("X-Appwrite-Key: " + apiKey);
+
+    std::string response;
+    int statusCode = Utils::getRequest(url, headers, response);
+
+    if (statusCode == HttpStatus::OK) {
+        return response;
+    } else {
+        throw AppwriteException(
+            "Error fetching message targets. Status code: " + std::to_string(statusCode) +
+            "\n\nResponse: " + response);
+    }
+}


### PR DESCRIPTION
Added listTargets function to fetch message targets

•Uses messageId to retrieve all associated targets.
•Supports optional query parameters for filtering.

<img width="1569" height="343" alt="Screenshot 2025-08-07 001338" src="https://github.com/user-attachments/assets/55abd647-4d33-4687-8873-1be520fe5b5b" />
<img width="1260" height="288" alt="Screenshot 2025-08-07 001326" src="https://github.com/user-attachments/assets/6606327e-0f18-44de-b5de-2c36300dcb6d" />
<img width="1160" height="718" alt="Screenshot 2025-08-07 001315" src="https://github.com/user-attachments/assets/a96555ff-aa8f-459d-a326-90ed36d0f323" />

closes #112 