### PR TITLE
Added ``updateSms`` method to update an existing sms message

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -291,6 +291,10 @@ createEmail: $(SRCS) $(EXAMPLES_DIR)/messaging/messages/createEmail.cpp
 	@mkdir -p ./$(TESTS_DIR)
 	$(CXX) $(CXXFLAGS) -o ./$(TESTS_DIR)/createEmail $(SRCS) $(EXAMPLES_DIR)/messaging/messages/createEmail.cpp $(LDFLAGS)
 
+updateSms: $(SRCS) $(EXAMPLES_DIR)/messaging/messages/updateSms.cpp
+	@mkdir -p ./$(TESTS_DIR)
+	$(CXX) $(CXXFLAGS) -o ./$(TESTS_DIR)/updateSms $(SRCS) $(EXAMPLES_DIR)/messaging/messages/updateSms.cpp $(LDFLAGS)
+
 # Messaging - Topics
 getTopic: $(SRCS) $(EXAMPLES_DIR)/messaging/topics/getTopic.cpp
 			@mkdir -p ./$(TESTS_DIR)

--- a/examples/messaging/messages/createSms.cpp
+++ b/examples/messaging/messages/createSms.cpp
@@ -8,10 +8,8 @@ int main() {
 
     Appwrite appwrite(projectId, apiKey);
 
-    std::string messageId = "6b309gbdfjhfjsk4016e14b8";
-    std::string subject = "Hello from C++ Appwrite SDK!";
-    std::string content =
-        "Testing SMS message creation with topics, users, and targets.";
+    std::string messageId = "msg001";
+    std::string content = "Testing SMS message creation.";
 
     std::vector<std::string> topics = {};
     std::vector<std::string> users = {};

--- a/examples/messaging/messages/updateSms.cpp
+++ b/examples/messaging/messages/updateSms.cpp
@@ -11,7 +11,7 @@ int main() {
     std::string messageId = "6b309gbdfjhfjsk4016e14b8";
     std::string subject = "Hello from C++ Appwrite SDK!";
     std::string content =
-        "Testing SMS message creation with topics, users, and targets.";
+        "Testing SMS message updation with topics, users, and targets.";
 
     std::vector<std::string> topics = {};
     std::vector<std::string> users = {};
@@ -32,9 +32,9 @@ int main() {
     bool draft = true;
 
     try {
-        std::string response = appwrite.getMessaging().createSms(
-            messageId, content, topics, users, targets, draft, scheduled_at);
-        std::cout << "SMS Message Created!\nResponse: " << response
+        std::string response = appwrite.getMessaging().updateSms(
+            messageId, topics, users, targets, content, draft, scheduled_at);
+        std::cout << "SMS Message updated!\nResponse: " << response
                   << std::endl;
     } catch (const AppwriteException &ex) {
         std::cerr << "Exception: " << ex.what() << std::endl;

--- a/examples/messaging/messages/updateSms.cpp
+++ b/examples/messaging/messages/updateSms.cpp
@@ -8,10 +8,8 @@ int main() {
 
     Appwrite appwrite(projectId, apiKey);
 
-    std::string messageId = "6b309gbdfjhfjsk4016e14b8";
-    std::string subject = "Hello from C++ Appwrite SDK!";
-    std::string content =
-        "Testing SMS message updation with topics, users, and targets.";
+    std::string messageId = "msg001";
+    std::string content = "Testing SMS message updation.";
 
     std::vector<std::string> topics = {};
     std::vector<std::string> users = {};
@@ -24,10 +22,7 @@ int main() {
                   future_time.time_since_epoch()) %
               1000;
 
-    std::stringstream ss;
-    ss << std::put_time(std::gmtime(&time_t), "%Y-%m-%dT%H:%M:%S");
-    ss << "." << std::setfill('0') << std::setw(3) << ms.count() << "+00:00";
-    std::string scheduled_at = ss.str();
+    std::string scheduled_at = "";
 
     bool draft = true;
 

--- a/include/classes/Messaging.hpp
+++ b/include/classes/Messaging.hpp
@@ -206,6 +206,24 @@ class Messaging {
                             const std::vector<std::string> &attachments = {},
                             bool draft = false, bool html = false,
                             const std::string &scheduled_at = "");
+    /**
+     * @brief Update an existing sms message.
+     *
+     * @param messageId Unique ID for the message.
+     * @param topics List of topic IDs (optional).
+     * @param users List of User IDs (optional).
+     * @param targets List of target IDs (optional).
+     * @param content SMS Content.
+     * @param draft If true, saves the message as a draft.
+     * @param scheduled_at Scheduled delivery time for message.
+     * @return JSON response.
+     */
+    std::string updateSms(const std::string &messageId,
+                          const std::vector<std::string> &topics = {},
+                          const std::vector<std::string> &users = {},
+                          const std::vector<std::string> &targets = {},
+                          const std::string &content = "", bool draft = false,
+                          const std::string &scheduled_at = "");
 
     /**
      * @brief Updates an existing push notification
@@ -323,15 +341,15 @@ class Messaging {
     std::string listTargets(const std::string &messageId,
                             const std::vector<std::string> &queries = {});
 
-      /**
+    /**
      * @brief List all logs for a given topic.
      * @param topicID ID of the message.
      * @param queries Optional query filters.
      * @return JSON response.
-    */
+     */
     std::string listTopicLogs(const std::string &topicId,
                               const std::vector<std::string> &queries = {});
-  
+
   private:
     std::string projectId; ///< Project ID
     std::string apiKey;    ///< API Key

--- a/src/services/Messaging.cpp
+++ b/src/services/Messaging.cpp
@@ -548,6 +548,77 @@ std::string Messaging::createSms(const std::string &messageId,
     }
 }
 
+// Added method to update an existing SMS message
+std::string Messaging::updateSms(const std::string &messageId,
+                                 const std::vector<std::string> &topics,
+                                 const std::vector<std::string> &users,
+                                 const std::vector<std::string> &targets,
+                                 const std::string &content, bool draft,
+                                 const std::string &scheduled_at) {
+    if (messageId.empty()) {
+        throw AppwriteException("Missing required parameter: 'messageId'");
+    }
+
+    if (content.empty()) {
+        throw AppwriteException("Missing required parameter: 'content'");
+    }
+
+    std::string payload = "{";
+
+    payload += R"("topics":[)";
+    for (size_t i = 0; i < topics.size(); ++i) {
+        payload += "\"" + Utils::escapeJsonString(topics[i]) + "\"";
+        if (i != topics.size() - 1)
+            payload += ",";
+    }
+    payload += "]";
+
+    payload += R"(,"users":[)";
+    for (size_t i = 0; i < users.size(); ++i) {
+        payload += "\"" + Utils::escapeJsonString(users[i]) + "\"";
+        if (i != users.size() - 1)
+            payload += ",";
+    }
+    payload += "]";
+
+    payload += R"(,"targets":[)";
+    for (size_t i = 0; i < targets.size(); ++i) {
+        payload += "\"" + Utils::escapeJsonString(targets[i]) + "\"";
+        if (i != targets.size() - 1)
+            payload += ",";
+    }
+    payload += "]";
+
+    payload += R"(,"content":")" + Utils::escapeJsonString(content) + R"(")";
+
+    payload += std::string(R"(,"draft":)") + (draft ? "true" : "false");
+
+    if (!scheduled_at.empty()) {
+        payload += R"(,"scheduledAt":")" +
+                   Utils::escapeJsonString(scheduled_at) + "\"";
+    }
+
+    payload += "}";
+
+    std::string url = Config::API_BASE_URL + "/messaging/messages/sms/" +
+                      Utils::urlEncode(messageId);
+
+    std::vector<std::string> headers = Config::getHeaders(projectId);
+    headers.push_back("X-Appwrite-Key: " + apiKey);
+    headers.push_back("Content-Type: application/json");
+
+    std::string response;
+    int statusCode = Utils::patchRequest(url, payload, headers, response);
+
+    if (statusCode == HttpStatus::OK) {
+        return response;
+    } else {
+        throw AppwriteException("Error updating sms message. Status code: " +
+                                std::to_string(statusCode) +
+                                "\n\nResponse: " + response);
+    }
+}
+
 // Added method to create a new email message.
 std::string Messaging::createEmail(
     const std::string &messageId, const std::string &subject,


### PR DESCRIPTION
This PR adds the `updateSms()` method (issue #75) to update an existing SMS message via the Appwrite Messaging API.

### Changes made:
- `classes/Messaging.hpp` - Added declaration for `updateSms()` method
- `services/Messaging.cpp` - Implemented `updateSms()` method to update an existing SMS message
- `Makefile` - Added an entry for`updateSms()` method to compile and test it.
- `updateSms.cpp` - Added test to validate `updateSms()` functionality

### Test result:
<img width="953" height="460" alt="updateSms" src="https://github.com/user-attachments/assets/b429c2f1-f1b9-4085-8842-df22ccfac950" />
